### PR TITLE
Implement Chunked Reads

### DIFF
--- a/libslim/source/cache.c
+++ b/libslim/source/cache.c
@@ -42,7 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <nds/debug.h>
 #endif
 
-#define CHECK_BIT(v, p) (((v) >> (p)) & 1)
+#define CHECK_BIT(v, n) (((v) >> (n)) & 1)
 #define VALID(v) CHECK_BIT(v, 0)
 #define REFERENCED(v) CHECK_BIT(v, 1)
 #define BIT_SET(n)   (1 << (n))
@@ -134,9 +134,9 @@ BOOL cache_load_sector(CACHE *cache, BYTE drv, LBA_t sector, BYTE *dst)
     }
 
 #ifdef DEBUG_NOGBA
-    char block[256];
-    sprintf(block, "HIT: d: %d, s: %ld, b: %d", drv, sector, i);
-    nocashMessage(block);
+    // char block[256];
+    // sprintf(block, "HIT: d: %d, s: %ld, b: %d", drv, sector, i);
+    // nocashMessage(block);
 #endif
     // Set referenced bit
     cache[i].status |= 0b10;
@@ -168,9 +168,9 @@ void cache_store_sector(CACHE *cache, BYTE drv, LBA_t sector, const BYTE *src)
     }
 
 #ifdef DEBUG_NOGBA
-    char block[256];
-    sprintf(block, "S: d: %d, s: %ld, fb: %d, cs: %u", drv, sector, free_block, _cacheSize);
-    nocashMessage(block);
+    // char block[256];
+    // sprintf(block, "S: d: %d, s: %ld, fb: %d, cs: %u", drv, sector, free_block, _cacheSize);
+    // nocashMessage(block);
 #endif
 
     // Set valid and unreferenced
@@ -226,19 +226,20 @@ DWORD cache_get_existence_bitmap(CACHE *cache, BYTE drv, LBA_t sector, BYTE coun
 {
     if (!cache)
         return 0;
-    if (count > sizeof(DWORD) * CHAR_BIT)
+    if (count > SECTORS_PER_CHUNK)
         return 0;
-
+    
     DWORD bitmap = 0;
     for (int i = 0; i < _cacheSize; i++)
     {
         if (VALID(cache[i].status) && cache[i].pdrv == drv)
         {
+           
             int cachedSector = cache[i].sector;
             int relativeSector = cachedSector - sector;
             if (relativeSector < 0 || relativeSector >= count)
                 continue;
-            bitmap &= BIT_SET(relativeSector);
+            bitmap |= BIT_SET(relativeSector);
         }
     }
     return bitmap;

--- a/libslim/source/cache.c
+++ b/libslim/source/cache.c
@@ -234,7 +234,6 @@ DWORD cache_get_existence_bitmap(CACHE *cache, BYTE drv, LBA_t sector, BYTE coun
     {
         if (VALID(cache[i].status) && cache[i].pdrv == drv)
         {
-           
             int cachedSector = cache[i].sector;
             int relativeSector = cachedSector - sector;
             if (relativeSector < 0 || relativeSector >= count)

--- a/libslim/source/cache.h
+++ b/libslim/source/cache.h
@@ -51,6 +51,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 / 
 */
 
+#define SECTORS_PER_CHUNK (sizeof(DWORD) * CHAR_BIT)
+
 #if SLIM_USE_CACHE && FF_MAX_SS != FF_MIN_SS
     #error "Cache can only be used for fixed sector size."
 #endif

--- a/libslim/source/cache.h
+++ b/libslim/source/cache.h
@@ -113,5 +113,18 @@ BOOL cache_invalidate_sector(CACHE *cache, BYTE drv, LBA_t sector);
  */ 
 void cache_invalidate_all(CACHE *cache, BYTE drv);
 
+/**
+ * Gets the existence of up to count < 32 consecutive sectors starting
+ * from sector as a 32-bit bitmap.
+ * 
+ * For example, if sectors 4, 5, and 6 were cached, the query was 
+ * considered for sector = 3 and count = 8, the returned bitmap will be
+ * 0x0000000E (1110 in the first nibble is set.)
+ * 
+ * An unset bit does not necessarily mean that the sector is uncached.
+ * That may be the case, or it may be the case that it was not within
+ * the alloted count.
+ */ 
+DWORD cache_get_existence_bitmap(CACHE *cache, BYTE drv, LBA_t sector, BYTE count);
 #endif
 #endif

--- a/libslim/source/diskio.c
+++ b/libslim/source/diskio.c
@@ -194,9 +194,10 @@ DRESULT disk_read(
 		LBA_t sectorOffset = 0;
 		while (sectorsRemaining)
 		{
-			// BYTE sectorsToRead = MIN((BYTE)SECTORS_PER_CHUNK, sectorsRemaining);
-			const BYTE sectorsToRead = MIN(4, sectorsRemaining);
+			BYTE sectorsToRead = MIN((BYTE)SECTORS_PER_CHUNK, sectorsRemaining);
 #ifdef DEBUG_NOGBA
+			// Limiting to chunks of 4 to test correctness
+			sectorsToRead = MIN(4, sectorsRemaining);
 			sprintf(buf, "load: chunk of %d (%d remaining, total %ld/%d) sectors starting %ld", sectorsToRead, sectorsRemaining,
 					sectorOffset, count, baseSector + sectorOffset);
 			nocashMessage(buf);

--- a/libslim/source/diskio.c
+++ b/libslim/source/diskio.c
@@ -280,7 +280,7 @@ DRESULT disk_read(
 			}
 
 			// If
-			if (__builtin_popcount(readBitmap) != sectorsToRead)
+			if (__builtin_popcountl(readBitmap) != sectorsToRead)
 				return RES_ERROR;
 
 			sectorOffset += sectorsToRead;

--- a/libslim/source/diskio.c
+++ b/libslim/source/diskio.c
@@ -54,8 +54,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CHECK_BIT(v, n) (((v) >> (n)) & 1)
 #define BIT_SET(n) (1 << (n))
 
-#define DEBUG_NOGBA
-
 #ifdef DEBUG_NOGBA
 #include <nds/debug.h>
 #endif
@@ -144,8 +142,8 @@ DRESULT disk_read_internal(
 BYTE get_disk_lookahead(DWORD bitmap, BYTE currentSector, BYTE maxCount)
 {
 	if ((bitmap >> currentSector) == 0)
-		  return maxCount;
-    return MIN(maxCount, __builtin_ctzl(bitmap >> currentSector));
+		return maxCount;
+	return MIN(maxCount, __builtin_ctzl(bitmap >> currentSector));
 }
 
 DRESULT disk_read(
@@ -279,7 +277,8 @@ DRESULT disk_read(
 				i += lookaheadCount;
 			}
 
-			// If
+			// If the number of read sectors in the chunk is wrong
+			// we messed up.
 			if (__builtin_popcountl(readBitmap) != sectorsToRead)
 				return RES_ERROR;
 

--- a/libslim/source/ff.h
+++ b/libslim/source/ff.h
@@ -219,7 +219,7 @@ typedef struct {
 	DWORD*	cltbl;			/* Pointer to the cluster link map table (nulled on open, set by application) */
 #endif
 #if !FF_FS_TINY
-	BYTE	buf[FF_MAX_SS] __attribute__((aligned(4)));	/* File private data read/write window */
+	BYTE	buf[FF_MAX_SS] __attribute__((aligned(32)));	/* File private data read/write window */
 #endif
 } FIL;
 


### PR DESCRIPTION
* Determines the number of contiguous uncached sectors before making an SDIO request, making as few requests as possible
* Greedy method of fetching uncached sectors is provably the least possible SD accesses for a given file